### PR TITLE
Increase portability with aliases

### DIFF
--- a/boards/aludel_mini_v1_sparkfun9160_ns.overlay
+++ b/boards/aludel_mini_v1_sparkfun9160_ns.overlay
@@ -1,17 +1,23 @@
-&i2c1 {
-    status = "okay";
-	zephyr,concat-buf-size = <48>;
-    bme280@76 {
-        compatible = "bosch,bme280";
-        reg = <0x76>;
-        label = "BME280_I2C";
-    };
+/ {
+        aliases {
+                click-i2c = &i2c1;
+        };
+};
 
-    apds9960: apds9960@39 {
-		compatible = "avago,apds9960";
+&i2c1 {
+        status = "okay";
+	zephyr,concat-buf-size = <48>;
+        
+        bme280@76 {
+                compatible = "bosch,bme280";
+                reg = <0x76>;
+                label = "BME280_I2C";
+        };
+
+        apds9960: apds9960@39 {
+	        compatible = "avago,apds9960";
 		reg = <0x39>;
 		label = "APDS9960";
 		int-gpios = <&gpio0 16 (GPIO_ACTIVE_LOW)>;
-	};
-
+        };
 };

--- a/src/app_work.c
+++ b/src/app_work.c
@@ -75,7 +75,7 @@ void app_work_sensor_read(void) {
 	int16_t bat_voltage = 0;
 	int16_t rrsp = 0;
 
-	const struct device *i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c1));
+	const struct device *i2c_dev = DEVICE_DT_GET(DT_ALIAS(click_i2c));
 	if (i2c_dev==NULL||!device_is_ready(i2c_dev))
 	{
 		LOG_ERR("Could not get i2c device\n");


### PR DESCRIPTION
To have code portability across multiple platforms, I've added an alias for the I2C interface used in this project.